### PR TITLE
prettify + fix

### DIFF
--- a/APlagueTaleInnocence.asl
+++ b/APlagueTaleInnocence.asl
@@ -2,121 +2,117 @@
 
 state("APlagueTaleInnocence_x64", "Steam")
 {
-    bool loading : "WwiseLibPCx64R.dll", 0x262521;
-    int playerControl : 0x152E91C;
-    string50 Map : 0x015206E0, 0x88, 0x0, 0xD0, 0x990, 0x260;
+    bool     Loading       : "WwiseLibPCx64R.dll", 0x262521;
+    int      PlayerControl : 0x152E91C;
+    string50 MapName       : 0x15206E0, 0x88, 0x0, 0xD0, 0x990, 0x260;
 }
 
 state("APlagueTaleInnocence_x64", "Epic")
 {
-    bool loading : "WwiseLibPCx64R.dll", 0x262521;
-    int playerControl : 0x152E6DC;
-    string50 Map : 0x016AADC0, 0x10, 0x110, 0xD8, 0x10, 0x30, 0x170, 0x260;
+    bool     Loading       : "WwiseLibPCx64R.dll", 0x262521;
+    int      PlayerControl : 0x152E6DC;
+    string50 MapName       : 0x16AADC0, 0x10, 0x110, 0xD8, 0x10, 0x30, 0x170, 0x260;
 }
 
 state("APlagueTaleInnocence_x64", "Xbox")
 {
-    bool loading : "WwiseLibPCx64R.dll", 0x262521; 
-    int playerControl : 0x1744EBC;
-    string50 Map : "MessageBus.dll", 0x005C0DE0, 0x340, 0x668; 
-}
-
-init
-{
-    switch (modules.First().ModuleMemorySize) { // This is to know what version you are playing on
-        case  25473024: version = "Steam"; // Meta add the module size here
-            break;
-        case    25284608: version = "Epic"; 
-            break;
-        case    27566080: version = "Xbox"; 
-            break;
-        default:        version = ""; 
-            break;
-    }
-    vars.doneMaps = new List<string>();
+    bool     Loading       : "WwiseLibPCx64R.dll", 0x262521;
+    int      PlayerControl : 0x1744EBC;
+    string50 MapName       : "MessageBus.dll", 0x5C0DE0, 0x340, 0x668;
 }
 
 startup
 {
-    settings.Add("APT", true, "All Chapters");
-
-    vars.Chapters = new Dictionary<string,string> 
-	{
-        //{"DOMAIN","Chapter 1 - The de Rune Legacy"},
-        {"VILLAGE","Chapter 2 - The Strangers"},
-        {"VILLAGE2","Chapter 3 - Retribution"},
-        {"FARM","Chapter 4 - The Apprentice"},
-        {"BATTLEFIELD","Chapter 5 - The Ravens' Spoils"},
-        {"BATTLEFIELD2","Chapter 6 - Damaged Goods"},
-        {"SHELTER_FOREST","Chapter 7 - The Path Before Us"},
-        {"SHELTER_MORNING","Chapter 8 - Our Home"},
-        {"UNIVERSITY","Chapter 9 - In the Shadow of Ramparts"},
-        {"UNIVERSITY2","Chapter 10 - The Way of Roses"},
-        {"SHELTER_SAFE","Chapter 11 - Alive"},
-        {"CORRUPTED_DOMAIN","Chapter 12 - All That Remains"},
-        {"ILLUSION","Chapter 13 - Penance"},
-        {"INQUISITION","Chapter 14 - Blood Ties"},
-        {"SHELTER_SIEGE","Chapter 15 - Remembrance"},
-        {"CATHEDRAL","Chapter 16 - Coronation"},
-        {"EPILOGUE","Chapter 17 - For Each Other"},
+    var Chapters = new Dictionary<string,string>
+    {
+        // { "DOMAIN",           "Chapter 1 - The de Rune Legacy" },
+        { "VILLAGE",          "Chapter 2 - The Strangers" },
+        { "VILLAGE2",         "Chapter 3 - Retribution" },
+        { "FARM",             "Chapter 4 - The Apprentice" },
+        { "BATTLEFIELD",      "Chapter 5 - The Ravens' Spoils" },
+        { "BATTLEFIELD2",     "Chapter 6 - Damaged Goods" },
+        { "SHELTER_FOREST",   "Chapter 7 - The Path Before Us" },
+        { "SHELTER_MORNING",  "Chapter 8 - Our Home" },
+        { "UNIVERSITY",       "Chapter 9 - In the Shadow of Ramparts" },
+        { "UNIVERSITY2",      "Chapter 10 - The Way of Roses" },
+        { "SHELTER_SAFE",     "Chapter 11 - Alive" },
+        { "CORRUPTED_DOMAIN", "Chapter 12 - All That Remains" },
+        { "ILLUSION",         "Chapter 13 - Penance" },
+        { "INQUISITION",      "Chapter 14 - Blood Ties" },
+        { "SHELTER_SIEGE",    "Chapter 15 - Remembrance" },
+        { "CATHEDRAL",        "Chapter 16 - Coronation" },
+        { "EPILOGUE",         "Chapter 17 - For Each Other" }
     };
-    foreach (var Tag in vars.Chapters)
-		{
-			settings.Add(Tag.Key, true, Tag.Value, "APT");
-    	};
 
-    vars.onStart = (EventHandler)((s, e) => // thanks gelly for this, it's basically making sure it always clears the vars no matter how livesplit starts
-        {
-            vars.doneMaps.Clear(); // Needed because checkpoints bad in game 
-            vars.doneMaps.Add(current.Map.Split('>')[1]); // Adding for the starting map because it's also bad
-        });
-    timer.OnStart += vars.onStart; 
+    foreach (var chapter in Chapters)
+        settings.Add(chapter.Key, true, chapter.Value);
 
-	if (timer.CurrentTimingMethod == TimingMethod.RealTime)
-        // Asks user to change to game time if LiveSplit is currently set to Real Time.
-        {        
-            var timingMessage = MessageBox.Show (
-                "This game uses Time without Loads (Game Time) as the main timing method.\n"+
-                "LiveSplit is currently set to show Real Time (RTA).\n"+
-                "Would you like to set the timing method to Game Time?",
-                "LiveSplit | A Plague Tale Innocence",
-                MessageBoxButtons.YesNo,MessageBoxIcon.Question
-            );
-        
+    vars.OnStart = (EventHandler)((s, e) => vars.DoneMaps = new List<string> { current.Map });
+    timer.OnStart += vars.OnStart;
+
+    if (timer.CurrentTimingMethod == TimingMethod.RealTime)
+    {
+        var timingMessage = MessageBox.Show (
+            "Removing loads from A Plague Tale: Innocence requires comparing against Game Time.\n" +
+            "Would you like to switch to it?",
+            "LiveSplit | A Plague Tale: Innocence",
+            MessageBoxButtons.YesNo);
+
         if (timingMessage == DialogResult.Yes)
-        {
             timer.CurrentTimingMethod = TimingMethod.GameTime;
-        }
     }
 }
 
-start
+init
 {
-    return (current.Map.Contains("DOMAIN") && current.playerControl == 4024 && old.playerControl == 4025);
+    switch (game.MainModule.ModuleMemorySize)
+    {
+        case 0x184B000: version = "Steam"; break;
+        case 0x181D000: version = "Epic"; break;
+        case 0x1A4A000: version = "Xbox"; break;
+        default: version = "Unknown!"; break;
+    }
+
+    current.Map = "";
+    vars.DoneMaps = new List<string>();
 }
 
 update
 {
-//DEBUG CODE
-//  print(current.loading.ToString());  
-// print(current.Map.Split('>')[1].ToString());
-}        
+    if (version == "Unknown!") return false;
+
+    current.Map = current.MapName.Split('>')[1];
+
+    // DEBUG CODE
+    // print(current.Loading.ToString());
+    // print(current.MapName.Split('>')[1].ToString());
+}
+
+start
+{
+    return current.MapName.Contains("DOMAIN") && current.PlayerControl == 4024 && old.PlayerControl == 4025;
+}
 
 split
 {
-    if (settings[current.Map.Split('>')[1]] && (!vars.doneMaps.Contains(current.Map.Split('>')[1])))
+    if (settings[current.Map] && !vars.DoneMaps.Contains(current.Map))
     {
-        vars.doneMaps.Add(current.Map.Split('>')[1]);
+        vars.DoneMaps.Add(current.Map);
         return true;
     }
 }
 
 isLoading
 {
-    return current.loading;
+    return current.Loading;
 }
 
 exit
 {
-	timer.IsGameTimePaused = true;
+    timer.IsGameTimePaused = true;
+}
+
+shutdown
+{
+    timer.OnStart -= vars.OnStart;
 }


### PR DESCRIPTION
edit as you wish before merging;

* use consistent indentations (4 spaces)  
* use same naming convention (PascalCase)  
* don't use global `vars` for settings loop when dictionary is only used once ever  
* indent some code for better readability  
* shorten `timingMessage` for clarity  
* convert map name to actual map (`MapName.Split('>')[1]`), since it's only used in this form ever  
* unsubscribe `vars.OnStart` from `timer.OnStart` in `shutdown {}`, since it would otherwise keep running that code when the script unloads  
* shorten OnStart logic  
* change first module to `game.MainModule` (more consistent, `modules.First()` is not guaranteed to be the executable)  
* convert module sizes to hexadecimal (memory is most often in hex numbers)
* disable script if version not found
* change order to reflect actual run order of the script